### PR TITLE
Fix handling of `ast.SyntaxError` in Python 3.10+

### DIFF
--- a/ftplugin/python/flaker.py
+++ b/ftplugin/python/flaker.py
@@ -75,7 +75,9 @@ def check(buffer):
     except:
         exc_value = sys.exc_info()[1]
         try:
-            lineno, offset, line = exc_value.args[1][1:]
+            lineno = exc_value.lineno
+            offset = exc_value.offset
+            line = exc_value.text
         except IndexError:
             lineno, offset, line = 1, 0, ''
         if line and line.endswith("\n"):


### PR DESCRIPTION
In Python 3.10+, the [`ast.SyntaxError` class in Python 3.10+](https://docs.python.org/3/library/exceptions.html#SyntaxError) has changed such that the following pyflakes-vim code blows up, resulting in a massive spew of error messages in vim whenever a syntax error is encountered:
```
>               lineno, offset, line = exc_value.args[1][1:]
E               ValueError: too many values to unpack (expected 3)
```
This PR fixes the issue by retrieving the desired `SyntaxError` properties using more reliable, direct property access rather than destructuring `exc_value.args[1]` so that it works correctly on newer Python versions (without breaking support for older versions, AFAICT).

---

See also the upstream PR: [kevinw/pyflakes-vim #79](https://github.com/kevinw/pyflakes-vim/pull/79).